### PR TITLE
Fix Electron web worker node integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ When using TypeScript, make sure this setting is part of your TypeScript configu
 }
 ```
 
+## Electron
+
+To use standard Node packages in Electron web workers, make sure Node integration in workers is [turned on](https://www.electronjs.org/docs/tutorial/multithreading)
+and the plugin option [target](#target) is set to `electron-node-worker`.
+
 ## Options
 
 In most cases, no options are necessary to use WorkerPlugin.
@@ -151,6 +156,23 @@ module.exports = {
   ]
   <...>
 }
+```
+
+### `target` 
+
+Due to the way webpack works, it may be necessary to change the target environment of the workers.
+
+Possible values:
+
+- `electron-node-worker` use this if you are using Electron and compiling web workers that have node integration enabled. See [Electron Multithreading](https://www.electronjs.org/docs/tutorial/multithreading).
+
+Default value: `undefined`
+
+Example with electron node workers:
+```js
+new ThreadsPlugin({
+  target: 'electron-node-worker'
+})
 ```
 
 ## License

--- a/src/loader.js
+++ b/src/loader.js
@@ -18,6 +18,7 @@ import loaderUtils from 'loader-utils';
 import SingleEntryPlugin from 'webpack/lib/SingleEntryPlugin';
 import WebWorkerTemplatePlugin from 'webpack/lib/webworker/WebWorkerTemplatePlugin';
 import FetchCompileWasmTemplatePlugin from 'webpack/lib/web/FetchCompileWasmTemplatePlugin';
+import NodeTargetPlugin from 'webpack/lib/node/NodeTargetPlugin';
 import WORKER_PLUGIN_SYMBOL from './symbol';
 
 const NAME = 'WorkerPluginLoader';
@@ -57,6 +58,9 @@ export function pitch (request) {
 
   const workerCompiler = this._compilation.createChildCompiler(NAME, workerOptions, plugins);
   workerCompiler.context = this._compiler.context;
+  if (pluginOptions.target === "electron-node-worker") {
+    new NodeTargetPlugin().apply(workerCompiler);
+  }
   (new WebWorkerTemplatePlugin(workerOptions)).apply(workerCompiler);
   (new FetchCompileWasmTemplatePlugin({
     mangleImports: compilerOptions.optimization.mangleWasmImports


### PR DESCRIPTION
- Add target option `electron-node-worker` for Electron web workers with node integration enabled.
- Add `NodeTargetPlugin` to worker compiler when `target === "electron-node-worker"`.
- Update docs.

Closes #13.