### PR TITLE
Support any *node* webpack target

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -58,7 +58,8 @@ export function pitch (request) {
 
   const workerCompiler = this._compilation.createChildCompiler(NAME, workerOptions, plugins);
   workerCompiler.context = this._compiler.context;
-  if (pluginOptions.target === "electron-node-worker") {
+
+  if (pluginOptions.target && /\bnode\b/.test(pluginOptions.target)) {
     new NodeTargetPlugin().apply(workerCompiler);
   }
   (new WebWorkerTemplatePlugin(workerOptions)).apply(workerCompiler);


### PR DESCRIPTION
Support any `*node*` `target` webpack option, not just `electron-node-worker`.