### PR TITLE
Don't require `target` to be set in plugin options

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -59,7 +59,9 @@ export function pitch (request) {
   const workerCompiler = this._compilation.createChildCompiler(NAME, workerOptions, plugins);
   workerCompiler.context = this._compiler.context;
 
-  if (pluginOptions.target && /\bnode\b/.test(pluginOptions.target)) {
+  const target = pluginOptions.target || compilerOptions.target
+
+  if (target && /\bnode\b/.test(target)) {
     new NodeTargetPlugin().apply(workerCompiler);
   }
   (new WebWorkerTemplatePlugin(workerOptions)).apply(workerCompiler);


### PR DESCRIPTION
Read `target` option from either plugin options or webpack options. Fixes andywer/threads.js#291.